### PR TITLE
template1 as default database for Postgres

### DIFF
--- a/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
+++ b/lib/Doctrine/DBAL/Driver/PDOPgSql/Driver.php
@@ -89,6 +89,9 @@ class Driver extends AbstractPostgreSQLDriver
         if (isset($params['dbname'])) {
             $dsn .= 'dbname=' . $params['dbname'] . ' ';
         }
+        else {
+            $dsn .= 'dbname=template1' . ' ';
+        }
 
         if (isset($params['sslmode'])) {
             $dsn .= 'sslmode=' . $params['sslmode'] . ' ';


### PR DESCRIPTION
Fixes #402 (https://github.com/doctrine/DoctrineBundle/issues/402) by connecting by default to 'template1' instead of the database with the same name as the user (Postgre default in case of no dbname).